### PR TITLE
org-type return mismatch

### DIFF
--- a/cmd/organizations.go
+++ b/cmd/organizations.go
@@ -25,7 +25,7 @@ func organizationsTable(orgOutput interface{}) table.Model {
 				"name": org.Name,
 			}))
 		}
-	case cloudapiclient.OrganizationOutput:
+	case *cloudapiclient.OrganizationOutput:
 		rows = append(rows, table.NewRow(table.RowData{
 			"id":   data.Id,
 			"name": data.Name,
@@ -61,7 +61,7 @@ func organizationCreateRun() common.CobraRunE {
 			return err
 		}
 
-		orgsTable := organizationsTable(result.Result.(cloudapiclient.OrganizationOutput))
+		orgsTable := organizationsTable(result.Result.(*cloudapiclient.OrganizationOutput))
 		// TODO - print with tea
 		fmt.Println("Created Organization(s)")
 		fmt.Println(orgsTable.View())


### PR DESCRIPTION
currently get awkward panic in debugger as a result of incorrect type assertion on output for table (regression i likely introduced):

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/2961973/179234592-84c5f068-4321-43b9-bf06-2673e19c969c.png">

`org ls` itself is fine and it was created, this is really just to avoid the panic for now:

<img width="634" alt="image" src="https://user-images.githubusercontent.com/2961973/179234639-265ec3fb-9099-44ac-bfc1-f03341c89f49.png">
