### PR TITLE
fix: updated config env logic

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -132,18 +133,23 @@ func initConfig() func() {
 		}
 
 		vconfig.AutomaticEnv()
+		vconfig.SetEnvPrefix("APTIBLE")
+		// transform viper/cobra keys with underscores for environment variables
+		replacer := strings.NewReplacer("-", "_")
+		vconfig.SetEnvKeyReplacer(replacer)
 
+		if err := vconfig.ReadInConfig(); err == nil {
+			fmt.Println("Using common file:", vconfig.ConfigFileUsed())
+		}
+
+		token = vconfig.GetString("token")
 		if token == "" {
 			token, err = config.FindToken(home, fmt.Sprintf("https://%s", authDomain))
 			if err != nil {
 				fmt.Println("Unable to load token")
 				os.Exit(1)
 			}
-		}
-		vconfig.Set("token", token)
-
-		if err := vconfig.ReadInConfig(); err == nil {
-			fmt.Println("Using common file:", vconfig.ConfigFileUsed())
+			vconfig.Set("token", token)
 		}
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -27,11 +27,6 @@ type CobraRunE func(cmd *cobra.Command, args []string) error
 
 // FindToken - tries to find an aptible token in various paths
 func FindToken(home string, domain string) (string, error) {
-	if os.Getenv("APTIBLE_TOKEN") != "" {
-		// TODO - find a better way to do this
-		return os.Getenv("APTIBLE_TOKEN"), nil
-	}
-
 	var tokenObj map[string]string
 	text, err := os.ReadFile(path.Join(home, ".aptible", "tokens.json"))
 	if err != nil {
@@ -46,14 +41,7 @@ func FindToken(home string, domain string) (string, error) {
 }
 
 func NewCloudConfig(v *viper.Viper) *CloudConfig {
-	var host string
-	if os.Getenv("APTIBLE_API_DOMAIN") != "" {
-		// TODO - find a better way to do this
-		host = os.Getenv("APTIBLE_API_DOMAIN")
-	} else {
-		host = v.GetString("api-domain")
-	}
-
+	host := v.GetString("api-domain")
 	token := v.GetString("token")
 	debug := v.GetBool("debug")
 	cc := client.NewClient(debug, host, token)


### PR DESCRIPTION
This commit makes it so environment variables will automatically be pulled in using `APTIBLE_` prefix.  This makes `AutomaticEnv` work properly and removes the need to manually check for environment variables.