### PR TITLE
feat: adds `asset bundle` command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/evertras/bubble-table v0.14.4
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.0
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 )
 
 require (
@@ -40,7 +41,6 @@ require (
 	golang.org/x/net v0.0.0-20220728181054-f92ba40d432d // indirect
 	golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c // indirect
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect

--- a/ui/common/table.go
+++ b/ui/common/table.go
@@ -13,6 +13,12 @@ func DefaultRowStyle() lipgloss.Style {
 		Align(lipgloss.Center)
 }
 
+func LeftRowStyle() lipgloss.Style {
+	return lipgloss.NewStyle().
+		Foreground(white).
+		Align(lipgloss.Left)
+}
+
 func DisabledRowStyle() lipgloss.Style {
 	return lipgloss.NewStyle().
 		Foreground(red).


### PR DESCRIPTION
This commit adds a subcommand to `asset` to display all available asset bundles for a particular environment.

![Screen Shot 2022-09-20 at 3 18 52 PM](https://user-images.githubusercontent.com/1940365/191345721-1dadf442-f71a-4b70-a8a1-57098f73cef3.png)
